### PR TITLE
Port GTK+ example to GTK+ 3

### DIFF
--- a/Authors
+++ b/Authors
@@ -1,1 +1,2 @@
 Czarek Tomczak <czarek.tomczak@@gmail.com>
+Jiří Janoušek <janousek.jiri@gmail.com>

--- a/Authors
+++ b/Authors
@@ -1,2 +1,2 @@
 Czarek Tomczak <czarek.tomczak@@gmail.com>
-Jiří Janoušek <janousek.jiri@gmail.com>
+Jiří Janoušek <janousek.jiri@@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-all:
+info:
+	@echo "Use 'make gtk2' for GTK+ 2 example, or 'make gtk3' for GTK+ 3 example."
+gtk2:
 	@echo "----------------------------------------------------------------------"
-	@rm -f Release/cefcapi.out
+	@rm -f Release/cefcapi-gtk2
 	@clear
-	gcc -std=c99 -Wall -Werror -o Release/cefcapi.out -I. -I.. -Wl,-rpath,. -L./Release examples/main_linux.c -lX11 -lcef `pkg-config --libs --cflags gtk+-2.0`
-	cd Release/ && ./cefcapi.out && cd ../
+	gcc -std=c99 -Wall -Werror -o Release/cefcapi-gtk2 -I. -I.. -Wl,-rpath,. -L./Release examples/main_linux.c -lX11 -lcef `pkg-config --libs --cflags gtk+-2.0`
+	cd Release/ && ./cefcapi-gtk2 && cd ../
+gtk3:
+	@echo "----------------------------------------------------------------------"
+	@rm -f Release/cefcapi-gtk3
+	@clear
+	gcc -std=c99 -Wall -Werror -o Release/cefcapi-gtk3 -I. -I.. -Wl,-rpath,. -L./Release examples/main_linux.c -lX11 -lcef `pkg-config --libs --cflags gtk+-3.0`
+	cd Release/ && ./cefcapi-gtk3 && cd ../
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tested configurations:
     - Compilers: mingw-gcc 5.3.0 and TDM-gcc 5.1.0 on Windows 7 64-bit
 - Linux:
     - Binary: `cef_binary_3.3202.1692.g18a939d_linux64.tar.bz2`
-    - Compiler: Linux: gcc 4.8.2 on Ubuntu 14.04 64-bit
+    - Compiler: gcc 6.3.0 on Debian 9.2 (stretch) 64-bit
 
 
 ## Getting started
@@ -44,7 +44,8 @@ Tested configurations:
 2. Create cefcapi/Release/ directory
 3. Copy cef_binary*/Release/* to cefcapi/Release/
 4. Copy cef_binary*/Resources/* to cefcapi/Release/
-5. On Linux run the "make" command in the root directory
+5. On Linux run "make gtk2" (GTK+ 2 example) or "make gtk3" (GTK+ 3 example) in the root directory.
+   Note that you may need to build CEF with "use_gtk3=true" to link it with GTK+ 3.
 6. On Windows run the "build.bat" script in the root directory
 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tested configurations:
     - Compilers: mingw-gcc 5.3.0 and TDM-gcc 5.1.0 on Windows 7 64-bit
 - Linux:
     - Binary: `cef_binary_3.3202.1692.g18a939d_linux64.tar.bz2`
+    - Compiler: Linux: gcc 4.8.2 on Ubuntu 14.04 64-bit
     - Compiler: gcc 6.3.0 on Debian 9.2 (stretch) 64-bit
 
 

--- a/examples/gtk.h
+++ b/examples/gtk.h
@@ -15,7 +15,11 @@ void app_terminate_signal(int signatl) {
 }
 
 void initialize_gtk() {
-    printf("initialize_gtk\n");
+    #if GTK_CHECK_VERSION(3,0,0)
+    printf("initialize_gtk %u.%u.%u\n", gtk_get_major_version(), gtk_get_minor_version(), gtk_get_micro_version());
+    #else
+    printf("initialize_gtk 2\n");
+    #endif
     gtk_init(0, NULL);
     signal(SIGINT, app_terminate_signal);
     signal(SIGTERM, app_terminate_signal);
@@ -25,6 +29,32 @@ void window_destroy_signal(GtkWidget* widget, gpointer data) {
     printf("window_destroy_signal\n");
     cef_quit_message_loop();
 }
+
+
+static void fix_default_x11_visual(GtkWidget* widget) {
+    #if GTK_CHECK_VERSION(3,15,1)
+    // GTK+ > 3.15.1 uses an X11 visual optimized for GTK+'s OpenGL stuff
+    // since revid dae447728d: https://github.com/GNOME/gtk/commit/dae447728d
+    // However, it breaks CEF: https://github.com/cztomczak/cefcapi/issues/9
+    // Let's use the default X11 visual instead of the GTK's blessed one.
+    GdkScreen* screen = gdk_screen_get_default();
+    GList* visuals = gdk_screen_list_visuals(screen);
+    GdkX11Screen* x11_screen = GDK_X11_SCREEN(screen);
+    g_return_if_fail(x11_screen != NULL);
+    Visual* default_xvisual = DefaultVisual(GDK_SCREEN_XDISPLAY(x11_screen), GDK_SCREEN_XNUMBER(x11_screen));
+    GList* cursor = visuals;
+    while (cursor != NULL) {
+        GdkVisual* visual = GDK_X11_VISUAL(cursor->data);
+        if (default_xvisual->visualid == gdk_x11_visual_get_xvisual(visual)->visualid) {
+            gtk_widget_set_visual(widget, visual);
+            break; 
+        }
+        cursor = cursor->next;
+    }
+    g_list_free(visuals);
+    #endif
+}
+
 
 GtkWidget* create_gtk_window(char* title, int width, int height) {
     printf("create_gtk_window\n");
@@ -51,10 +81,15 @@ GtkWidget* create_gtk_window(char* title, int width, int height) {
 
     // CEF requires a container. Embedding browser in a top
     // level window fails.
+    #if GTK_CHECK_VERSION(3,0,0)
+    GtkWidget* vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+    #else
     GtkWidget* vbox = gtk_vbox_new(0, 0);
+    #endif
     gtk_container_add(GTK_CONTAINER(window), vbox);
     
     // Show.
+    fix_default_x11_visual(GTK_WIDGET(window));
     gtk_widget_show_all(window);
 
     return vbox;

--- a/examples/main_linux.c
+++ b/examples/main_linux.c
@@ -84,7 +84,12 @@ int main(int argc, char** argv) {
     initialize_gtk();
     GtkWidget* gtk_window = create_gtk_window("cefcapi example", 800, 600);
     cef_window_info_t window_info = {};
+    #if GTK_CHECK_VERSION(3,0,0)
+    Window xid = gdk_x11_window_get_xid(gtk_widget_get_window(gtk_window));
+    #else
     Window xid = gdk_x11_drawable_get_xid(gtk_widget_get_window(gtk_window));
+    #endif
+    printf("Window xid %u\n", (unsigned) xid);
     window_info.parent_window = xid;
 
     // Copied from upstream cefclient. Install xlib error


### PR DESCRIPTION
- Use `make gtk2` to build GTK+ 2 example and `make gtk3` to build
  GTK+ 3 example.
- Note that you may need to build CEF with "use_gtk3=true" to link it
  with GTK+ 3.
- GTK+ port contains a workaround for incompatible X11 visuals since
  GTK+ 3.15.2 (issue #9).

Signed-off-by: Jiří Janoušek <janousek.jiri@gmail.com>